### PR TITLE
Use servant-snap instead of servant-server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 dist-newstyle
 result
+result-*
 result-android
 result-ios
 result-exe
 .attr-cache
 ghcid-output.txt
-.obelisk

--- a/.obelisk/impl/default.nix
+++ b/.obelisk/impl/default.nix
@@ -1,0 +1,8 @@
+# DO NOT HAND-EDIT THIS FILE
+let fetch = { private ? false, fetchSubmodules ? false, owner, repo, rev, sha256, ... }:
+  if !fetchSubmodules && !private then builtins.fetchTarball {
+    url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz"; inherit sha256;
+  } else (import <nixpkgs> {}).fetchFromGitHub {
+    inherit owner repo rev sha256 fetchSubmodules private;
+  };
+in import (fetch (builtins.fromJSON (builtins.readFile ./github.json)))

--- a/.obelisk/impl/github.json
+++ b/.obelisk/impl/github.json
@@ -1,0 +1,8 @@
+{
+  "owner": "obsidiansystems",
+  "repo": "obelisk",
+  "branch": "master",
+  "private": false,
+  "rev": "0133449c597afdb3d4aaeb7a6475610b7bca6c99",
+  "sha256": "0p8m58b461529rmhmn95ndddgh5b256p6i5b4iyhzsr9kmyjlsmv"
+}

--- a/.obelisk/impl/github.json
+++ b/.obelisk/impl/github.json
@@ -3,6 +3,6 @@
   "repo": "obelisk",
   "branch": "master",
   "private": false,
-  "rev": "0133449c597afdb3d4aaeb7a6475610b7bca6c99",
-  "sha256": "0p8m58b461529rmhmn95ndddgh5b256p6i5b4iyhzsr9kmyjlsmv"
+  "rev": "0aaa9c828be84404e9513b56f3abef077b132f61",
+  "sha256": "0aw9yj3hv8n4scwr5y1fb1sqxjwsmz1rznd81kndbpaykb4ca0zd"
 }

--- a/backend/backend.cabal
+++ b/backend/backend.cabal
@@ -12,8 +12,10 @@ library
                , frontend
                , obelisk-backend
                , obelisk-route
-               , wai
-               , warp
+               , servant
+               , servant-snap
+               , snap-core
+
   exposed-modules:
     Backend
   ghc-options: -Wall

--- a/backend/hie.yaml
+++ b/backend/hie.yaml
@@ -1,0 +1,1 @@
+cradle: { cabal: { component: "backend" } }

--- a/backend/src/Backend.hs
+++ b/backend/src/Backend.hs
@@ -3,40 +3,42 @@
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE OverloadedStrings #-}
+
 module Backend where
 
 import Frontend
 import Common.Api
 import Common.Route
-import Control.Concurrent (forkIO)
-import Network.Wai (Application)
+import Obelisk.Route
 import Obelisk.Backend
-import Servant ((:<|>) (..), Proxy (..), Server)
 
-import qualified Servant as Servant
-import qualified Network.Wai.Handler.Warp as Warp
+import Data.Proxy (Proxy (..))
+import Servant.API ((:<|>) (..))
+import Servant (serveSnap, Server)
+import Snap.Core (MonadSnap)
 
 api :: Proxy Api
 api = Proxy
 
-server :: Server Api
-server = add :<|> sub
+server :: MonadSnap m => Server Api l m
+server = add :<|> sub :<|> echo
   where
     add x y = return (x + y)
     sub x y = return (x - y)
+    echo = return "echo"
 
-app :: Application
-app = Servant.serve api server
+apiServer :: MonadSnap m => m ()
+apiServer = serveSnap api server
 
 backend :: Backend BackendRoute FrontendRoute
 backend = Backend
-  { _backend_run = \serve -> serve $ const $ return ()
-  , _backend_routeEncoder = backendRouteEncoder
+  { _backend_run = \serve -> serve $ \case
+      (BackendRoute_Api     :/ _)  -> apiServer
+      (BackendRoute_Missing :/ ()) -> return ()
+  , _backend_routeEncoder = fullRouteEncoder
   }
 
 mainBackend :: IO ()
 mainBackend = do
-  -- TODO: There is almost certainly a better and/or safer way of doing this:
-  _ <- forkIO $ Warp.run 8081 app
   runBackend backend frontend
-

--- a/backend/src/Backend.hs
+++ b/backend/src/Backend.hs
@@ -13,13 +13,10 @@ import Common.Route
 import Obelisk.Route
 import Obelisk.Backend
 
-import Data.Proxy (Proxy (..))
 import Servant.API ((:<|>) (..))
 import Servant (serveSnap, Server)
 import Snap.Core (MonadSnap)
 
-api :: Proxy Api
-api = Proxy
 
 server :: MonadSnap m => Server Api l m
 server = add :<|> sub :<|> echo

--- a/common/common.cabal
+++ b/common/common.cabal
@@ -9,7 +9,6 @@ library
                , obelisk-route
                , mtl
                , servant
-               , servant-server
                , text
 
   exposed-modules:

--- a/common/hie.yaml
+++ b/common/hie.yaml
@@ -1,0 +1,1 @@
+cradle: { cabal: { component: "common" } }

--- a/common/src/Common/Api.hs
+++ b/common/src/Common/Api.hs
@@ -2,18 +2,19 @@
 {-# LANGUAGE TypeOperators #-}
 
 module Common.Api where
-
-import Servant (JSON)
-import Servant.API ((:>), (:<|>) (..), Capture, Get)
+import Data.Text
+import Servant.API ((:>), (:<|>) (..), Capture, Get, JSON)
 
 commonStuff :: String
 commonStuff =
   "Here is a string defined in code common to the frontend and backend."
 
-type Api = Add :<|> Sub
+type Api = "api" :> (Add :<|> Sub :<|> Echo)
 
 type Add =
   "add" :> Capture "x" Integer :> Capture "y" Integer :> Get '[JSON] Integer
 
 type Sub =
   "sub" :> Capture "x" Integer :> Capture "y" Integer :> Get '[JSON] Integer
+
+type Echo = "echo" :> Get '[JSON] Text

--- a/common/src/Common/Api.hs
+++ b/common/src/Common/Api.hs
@@ -4,6 +4,7 @@
 module Common.Api where
 import Data.Text
 import Servant.API ((:>), (:<|>) (..), Capture, Get, JSON)
+import Data.Proxy (Proxy (..))
 
 commonStuff :: String
 commonStuff =
@@ -18,3 +19,6 @@ type Sub =
   "sub" :> Capture "x" Integer :> Capture "y" Integer :> Get '[JSON] Integer
 
 type Echo = "echo" :> Get '[JSON] Text
+
+api :: Proxy Api
+api = Proxy

--- a/common/src/Common/Route.hs
+++ b/common/src/Common/Route.hs
@@ -1,17 +1,18 @@
 {-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE LambdaCase #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE KindSignatures #-}
-{-# LANGUAGE EmptyCase #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE OverloadedStrings #-}
-
+{-# LANGUAGE TypeFamilies #-}
 module Common.Route where
 
+import Prelude hiding (id, (.))
+import Control.Category (id, (.))
 {- -- You will probably want these imports for composing Encoders.
 import Prelude hiding (id, (.))
 import Control.Category
@@ -19,7 +20,6 @@ import Control.Category
 
 import Data.Text (Text)
 import Data.Functor.Identity
-import Data.Functor.Sum
 
 import Obelisk.Route
 import Obelisk.Route.TH
@@ -27,29 +27,26 @@ import Obelisk.Route.TH
 data BackendRoute :: * -> * where
   -- | Used to handle unparseable routes.
   BackendRoute_Missing :: BackendRoute ()
-  -- You can define any routes that will be handled specially by the
-  -- backend here. i.e. These do not serve the frontend, but do something
-  -- different, such as serving static files.
+  BackendRoute_Api :: BackendRoute PageName
+  -- You can define any routes that will be handled specially by the backend here.
+  -- i.e. These do not serve the frontend, but do something different, such as serving static files.
 
 data FrontendRoute :: * -> * where
   FrontendRoute_Main :: FrontendRoute ()
-  -- This type is used to define frontend routes, i.e. ones for which the
-  -- backend will serve the frontend.
+  -- This type is used to define frontend routes, i.e. ones for which the backend will serve the frontend.
 
-backendRouteEncoder ::
-  Encoder (Either Text) Identity
-    (R (Sum BackendRoute (ObeliskRoute FrontendRoute))) PageName
-backendRouteEncoder = handleEncoder (const (InL BackendRoute_Missing :/ ())) $
-  pathComponentEncoder $ \case
-    InL backendRoute -> case backendRoute of
+fullRouteEncoder
+  :: Encoder (Either Text) Identity (R (FullRoute BackendRoute FrontendRoute)) PageName
+fullRouteEncoder = mkFullRouteEncoder
+  (FullRoute_Backend BackendRoute_Missing :/ ())
+  (\case
       BackendRoute_Missing -> PathSegment "missing" $ unitEncoder mempty
-    InR obeliskRoute -> obeliskRouteSegment obeliskRoute $ \case
-      -- The encoder given to PathEnd determines how to parse query parameters,
-      -- in this example, we have none, so we insist on it.
-      FrontendRoute_Main -> PathEnd $ unitEncoder mempty
+      BackendRoute_Api     -> PathSegment "api" $ id)
+
+  (\case
+      FrontendRoute_Main -> PathEnd $ unitEncoder mempty)
 
 concat <$> mapM deriveRouteComponent
   [ ''BackendRoute
   , ''FrontendRoute
   ]
-

--- a/default.nix
+++ b/default.nix
@@ -15,10 +15,17 @@ project ./. ({ pkgs, ... }: {
       rev    = "ec8723351c8245f29a88cc5e6250533d2d6f4761";
       sha256 = "1r8z95hpl6f5pql1f6a3plczahym09fdnxkcg3a6ildw6chmips0";
     };
+    servant-snap = pkgs.fetchFromGitHub {
+      owner  = "haskell-servant";
+      repo   = "servant-snap";
+      rev    = "af5172a6de5bb2a07eb1bf4c85952075ec6ecdf3";
+      sha256 = "0973iq3gc36qhiqnf5vp5djqsrz70srw1r7g73v8wamw04dx0g3z";
+    };
   };
 
   overrides = self: super: with pkgs.haskell.lib; {
     servant-reflex = doJailbreak super.servant-reflex;
+    hspec-snap     = dontCheck (self.callHackage "hspec-snap" "1.0.1.0" { });
   };
   shellToolOverrides = ghc: super: {
     ghcide = pkgs.haskell.lib.dontCheck ((ghc.override {

--- a/default.nix
+++ b/default.nix
@@ -12,8 +12,8 @@ project ./. ({ pkgs, ... }: {
     servant-reflex = pkgs.fetchFromGitHub {
       owner  = "imalsogreg";
       repo   = "servant-reflex";
-      rev    = "ec8723351c8245f29a88cc5e6250533d2d6f4761";
-      sha256 = "1r8z95hpl6f5pql1f6a3plczahym09fdnxkcg3a6ildw6chmips0";
+      rev    = "7e6a372939b4218c1d76a641dded8d85126346fd";
+      sha256 = "1a8xpndhh545ascw6ydrkpgs70iwmjpw2iqvl4qmcyw11g3nbizb";
     };
     servant-snap = pkgs.fetchFromGitHub {
       owner  = "haskell-servant";
@@ -32,27 +32,27 @@ project ./. ({ pkgs, ... }: {
       overrides = ghc: super: {
         lsp-test =
           pkgs.haskell.lib.dontCheck (ghc.callHackage "lsp-test" "0.6.1.0" { });
-        haddock-library = pkgs.haskell.lib.dontCheck
+          haddock-library = pkgs.haskell.lib.dontCheck
           (ghc.callHackage "haddock-library" "1.8.0" { });
-        haskell-lsp = pkgs.haskell.lib.dontCheck
+          haskell-lsp = pkgs.haskell.lib.dontCheck
           (ghc.callHackage "haskell-lsp" "0.19.0.0" { });
-        haskell-lsp-types = pkgs.haskell.lib.dontCheck
+          haskell-lsp-types = pkgs.haskell.lib.dontCheck
           (ghc.callHackage "haskell-lsp-types" "0.19.0.0" { });
-        regex-posix = pkgs.haskell.lib.dontCheck
+          regex-posix = pkgs.haskell.lib.dontCheck
           (ghc.callHackage "regex-posix" "0.96.0.0" { });
-        test-framework = pkgs.haskell.lib.dontCheck
+          test-framework = pkgs.haskell.lib.dontCheck
           (ghc.callHackage "test-framework" "0.8.2.0" { });
-        regex-base = pkgs.haskell.lib.dontCheck
+          regex-base = pkgs.haskell.lib.dontCheck
           (ghc.callHackage "regex-base" "0.94.0.0" { });
-        regex-tdfa = pkgs.haskell.lib.dontCheck
+          regex-tdfa = pkgs.haskell.lib.dontCheck
           (ghc.callHackage "regex-tdfa" "1.3.1.0" { });
-        shake =
-          pkgs.haskell.lib.dontCheck (ghc.callHackage "shake" "0.18.4" { });
-        hie-bios = pkgs.haskell.lib.dontCheck (ghc.callHackageDirect {
-          pkg = "hie-bios";
-          ver = "0.4.0";
-          sha256 = "19lpg9ymd9656cy17vna8wr1hvzfal94gpm2d3xpnw1d5qr37z7x";
-        } { });
+          shake =
+            pkgs.haskell.lib.dontCheck (ghc.callHackage "shake" "0.18.4" { });
+            hie-bios = pkgs.haskell.lib.dontCheck (ghc.callHackageDirect {
+              pkg = "hie-bios";
+              ver = "0.4.0";
+              sha256 = "19lpg9ymd9656cy17vna8wr1hvzfal94gpm2d3xpnw1d5qr37z7x";
+            } { });
       };
     }).callCabal2nix "ghcide" (pkgs.fetchFromGitHub {
       owner = "digital-asset";

--- a/default.nix
+++ b/default.nix
@@ -20,5 +20,38 @@ project ./. ({ pkgs, ... }: {
   overrides = self: super: with pkgs.haskell.lib; {
     servant-reflex = doJailbreak super.servant-reflex;
   };
-
+  shellToolOverrides = ghc: super: {
+    ghcide = pkgs.haskell.lib.dontCheck ((ghc.override {
+      overrides = ghc: super: {
+        lsp-test =
+          pkgs.haskell.lib.dontCheck (ghc.callHackage "lsp-test" "0.6.1.0" { });
+        haddock-library = pkgs.haskell.lib.dontCheck
+          (ghc.callHackage "haddock-library" "1.8.0" { });
+        haskell-lsp = pkgs.haskell.lib.dontCheck
+          (ghc.callHackage "haskell-lsp" "0.19.0.0" { });
+        haskell-lsp-types = pkgs.haskell.lib.dontCheck
+          (ghc.callHackage "haskell-lsp-types" "0.19.0.0" { });
+        regex-posix = pkgs.haskell.lib.dontCheck
+          (ghc.callHackage "regex-posix" "0.96.0.0" { });
+        test-framework = pkgs.haskell.lib.dontCheck
+          (ghc.callHackage "test-framework" "0.8.2.0" { });
+        regex-base = pkgs.haskell.lib.dontCheck
+          (ghc.callHackage "regex-base" "0.94.0.0" { });
+        regex-tdfa = pkgs.haskell.lib.dontCheck
+          (ghc.callHackage "regex-tdfa" "1.3.1.0" { });
+        shake =
+          pkgs.haskell.lib.dontCheck (ghc.callHackage "shake" "0.18.4" { });
+        hie-bios = pkgs.haskell.lib.dontCheck (ghc.callHackageDirect {
+          pkg = "hie-bios";
+          ver = "0.4.0";
+          sha256 = "19lpg9ymd9656cy17vna8wr1hvzfal94gpm2d3xpnw1d5qr37z7x";
+        } { });
+      };
+    }).callCabal2nix "ghcide" (pkgs.fetchFromGitHub {
+      owner = "digital-asset";
+      repo = "ghcide";
+      rev = "v0.1.0";
+      sha256 = "1kf71iix46hvyxviimrcv7kvsj67hcnnqlpdsmazmlmybf7wbqbb";
+    }) { });
+  };
 })

--- a/docker.nix
+++ b/docker.nix
@@ -1,0 +1,19 @@
+# to use this:
+# > nix-build docker.nix -o result-docker
+# > docker load --input ./result-docker
+# > docker run -p 8000:8000 ob-test
+
+{ nixpkgs ? import <nixpkgs> {} }:
+let
+  exe = (import ./. {}).exe;
+in
+ nixpkgs.pkgs.dockerTools.buildImage {
+    name = "obelisk-reflex-servant-example";
+    contents = exe;
+    config = {
+      Cmd = [ "${exe}/backend" ];
+      ExposedPorts = {
+        "8000/tcp" = {};
+      };
+    };
+ }

--- a/frontend/frontend.cabal
+++ b/frontend/frontend.cabal
@@ -11,7 +11,6 @@ library
                , obelisk-route
                , reflex-dom
                , servant
-               , servant-client
                , servant-reflex
                , obelisk-generated-static
                , text

--- a/frontend/hie.yaml
+++ b/frontend/hie.yaml
@@ -1,0 +1,1 @@
+cradle: { cabal: { component: "frontend" } }

--- a/frontend/src-bin/main.hs
+++ b/frontend/src-bin/main.hs
@@ -6,5 +6,5 @@ import Reflex.Dom
 
 main :: IO ()
 main = do
-  let Right validFullEncoder = checkEncoder backendRouteEncoder
+  let Right validFullEncoder = checkEncoder fullRouteEncoder
   run $ runFrontend validFullEncoder frontend

--- a/frontend/src/Frontend.hs
+++ b/frontend/src/Frontend.hs
@@ -1,6 +1,11 @@
+{-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE NoMonomorphismRestriction #-}
+{-# LANGUAGE OverloadedStrings #-}
+
 module Frontend where
 
 import qualified Data.Text as T
@@ -12,6 +17,23 @@ import Common.Api
 import Common.Route
 import Obelisk.Generated.Static
 
+import Data.Proxy
+import Servant.API ((:<|>)(..))
+import Servant.Reflex (BaseUrl(..), SupportsServantReflex, ReqResult, client, reqSuccess)
+
+
+getAdd  :: forall t m. (SupportsServantReflex t m) => Dynamic t (Either T.Text Integer) -> Dynamic t (Either T.Text Integer) -> Event t () -> m (Event t (ReqResult () Integer))
+getSub  :: forall t m. (SupportsServantReflex t m) => Dynamic t (Either T.Text Integer) -> Dynamic t (Either T.Text Integer) -> Event t () -> m (Event t (ReqResult () Integer))
+getEcho :: forall t m. (SupportsServantReflex t m) => Event t () -> m (Event t (ReqResult () T.Text))
+(getAdd :<|> getSub :<|> getEcho) = client api (Proxy :: Proxy (m :: * -> *)) (Proxy :: Proxy ()) (constDyn (BasePath "/"))
+
+comp :: forall t m. (SupportsServantReflex t m, DomBuilder t m, PostBuild t m, MonadHold t m) => m ()
+comp = do
+  (e,_) <- el' "button" $ text "echo"
+  r' <- getEcho $ domEvent Click e
+  dynText =<< holdDyn "Waiting" (T.pack . show . reqSuccess <$> r')
+  return ()
+
 frontend :: Frontend (R FrontendRoute)
 frontend = Frontend
   { _frontend_head = el "title" $ text "Obelisk Small Example"
@@ -19,4 +41,5 @@ frontend = Frontend
       text "Welcome to Obelisk!"
       el "p" $ text $ T.pack commonStuff
       elAttr "img" ("src" =: static @"obelisk.jpg") blank
+      prerender_ blank comp
   }

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,1 @@
+(import ./. {}).shells.ghc


### PR DESCRIPTION
A small improvement to run servant as part of the obelisk's snap backend instead of running it in a separate wai backend. Also some extra stuffs like generating the client api and enable ghcide.